### PR TITLE
Issue 2 fix - missing slash in api/user route

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,5 +1,5 @@
 // api router will mount other routers
 module.exports = (app) => {
   app.get('/', (req, res) => { res.send('hello world') });
-  app.use('api/users', require('./user/user.routes'));
+  app.use('/api/users', require('./user/user.routes'));
 }


### PR DESCRIPTION
Changes to index.js to resolve issue #2.

The route was not reachable due to typeo in route.

This was tested locally.

This PR should close issue #2.



